### PR TITLE
Show Exception while processing AsyncAPI

### DIFF
--- a/src/test/java/io/zenwave360/jsonrefparser/AsyncAPI.java
+++ b/src/test/java/io/zenwave360/jsonrefparser/AsyncAPI.java
@@ -1,0 +1,18 @@
+package io.zenwave360.jsonrefparser;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URI;
+
+public class AsyncAPI {
+    @Test
+    public void test() throws IOException {
+        final var parser = new $RefParser(URI.create("https://raw.githubusercontent.com/asyncapi/spec-json-schemas/refs/heads/master/schemas/3.0.0.json"));
+        final var schema = parser
+                .parse()
+                .dereference()
+                .mergeAllOf()
+                .getRefs().schema();
+    }
+}


### PR DESCRIPTION
[main] ERROR i.z.jsonrefparser.$RefParser - dereference - Error setting jsonPath: $['patternProperties']['^x-[\w\d\.\x2d_]+$'] in https://raw.githubusercontent.com/asyncapi/spec-json-schemas/refs/heads/master/schemas/3.0.0.json java.lang.reflect.UndeclaredThrowableException: null
	at jdk.proxy2/jdk.proxy2.$Proxy8.read(Unknown Source)
	at io.zenwave360.jsonrefparser.$RefParser.replaceWith$Ref($RefParser.java:321)
	at io.zenwave360.jsonrefparser.$RefParser.dereference($RefParser.java:301)
	at io.zenwave360.jsonrefparser.$RefParser.lambda$dereference$0($RefParser.java:309)
	at java.base/java.util.LinkedHashMap$LinkedEntrySet.forEach(LinkedHashMap.java:708)
	at io.zenwave360.jsonrefparser.$RefParser.dereference($RefParser.java:308)
	at io.zenwave360.jsonrefparser.$RefParser.lambda$dereference$0($RefParser.java:309)
	at java.base/java.util.LinkedHashMap$LinkedEntrySet.forEach(LinkedHashMap.java:708)