### PR TITLE
Bumping jackson version due to cve

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
     <slf4j-api.version>1.7.36</slf4j-api.version>
 
-    <jackson.version>2.18.3</jackson.version>
+    <jackson.version>2.20.1</jackson.version>
     <snakeyaml.version>2.4</snakeyaml.version>
     <json-path.version>2.9.0</json-path.version>
     <avro.version>1.8.2</avro.version>


### PR DESCRIPTION
Hi, it's me again!

I noticed that the current version of jackson on lib is exposed to https://www.cve.org/CVERecord?id=CVE-2024-47561

Even tho I don't think would be easy to exploit it, may be better to keep it patched!

(The first versions that are not affected are the 2.19.x, but, as already updating tried to place the last one)